### PR TITLE
🔀 :: (PiCK-247)ttl customization

### DIFF
--- a/src/main/kotlin/dsm/pick2024/global/config/cache/CacheConfig.kt
+++ b/src/main/kotlin/dsm/pick2024/global/config/cache/CacheConfig.kt
@@ -16,8 +16,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer
 class CacheConfig {
 
     @Bean
-    fun redisCacheConfiguration(): RedisCacheConfiguration {
-        return RedisCacheConfiguration.defaultCacheConfig()
+    fun redisCacheManagerBuilderCustomizer(): RedisCacheManagerBuilderCustomizer {
+        val defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
             .entryTtl(Duration.ofHours(2)) // 기본 TTL 2시간
             .disableCachingNullValues() // NULL 은 저장 안 됨
             .serializeKeysWith(
@@ -26,11 +26,6 @@ class CacheConfig {
             .serializeValuesWith(
                 RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer())
             )
-    }
-
-    @Bean
-    fun redisCacheManagerBuilderCustomizer(): RedisCacheManagerBuilderCustomizer {
-        val defaultCacheConfig = redisCacheConfiguration()
 
         val dayScheduleCacheConfig = defaultCacheConfig.entryTtl(Duration.ofMinutes(30))
         val monthScheduleCacheConfig = defaultCacheConfig.entryTtl(Duration.ofMinutes(30))

--- a/src/main/kotlin/dsm/pick2024/global/config/cache/CacheConfig.kt
+++ b/src/main/kotlin/dsm/pick2024/global/config/cache/CacheConfig.kt
@@ -1,10 +1,12 @@
 package dsm.pick2024.global.config.cache
 
 import java.time.Duration
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager.RedisCacheManagerBuilder
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
@@ -16,7 +18,7 @@ class CacheConfig {
     @Bean
     fun redisCacheConfiguration(): RedisCacheConfiguration {
         return RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofHours(2)) // 기본 TTL 60
+            .entryTtl(Duration.ofHours(2)) // 기본 TTL 2시간
             .disableCachingNullValues() // NULL 은 저장 안 됨
             .serializeKeysWith(
                 RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer())
@@ -24,5 +26,20 @@ class CacheConfig {
             .serializeValuesWith(
                 RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer())
             )
+    }
+
+    @Bean
+    fun redisCacheManagerBuilderCustomizer(): RedisCacheManagerBuilderCustomizer {
+        val defaultCacheConfig = redisCacheConfiguration()
+
+        val dayScheduleCacheConfig = defaultCacheConfig.entryTtl(Duration.ofMinutes(30))
+        val monthScheduleCacheConfig = defaultCacheConfig.entryTtl(Duration.ofMinutes(30))
+
+        return RedisCacheManagerBuilderCustomizer { builder: RedisCacheManagerBuilder ->
+            builder
+                .withCacheConfiguration("dayScheduleCache", dayScheduleCacheConfig)
+                .withCacheConfiguration("monthScheduleCache", monthScheduleCacheConfig)
+                .build()
+        }
     }
 }


### PR DESCRIPTION
close #247 
<img width="721" alt="스크린샷 2024-07-28 23 44 47" src="https://github.com/user-attachments/assets/2f7cc462-3f5d-4f85-a8c7-845897fcdb1b">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
  - Redis 캐시 매니저의 새로운 구성 메서드를 추가하여 캐싱 기능 향상.
  - 특정 캐시 이름(일정 캐시 및 월간 일정 캐시)에 대해 TTL(시간 제한)을 30분으로 설정할 수 있는 기능 구현. 

- **버그 수정**
  - 기존 캐시 구성 메서드에 대한 주석 번역 수정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->