### PR TITLE
🔀 :: (PiCK-274) login error

### DIFF
--- a/src/main/kotlin/dsm/pick2024/infrastructure/feign/client/dto/request/XquareRequest.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/feign/client/dto/request/XquareRequest.kt
@@ -1,6 +1,6 @@
 package dsm.pick2024.infrastructure.feign.client.dto.request
 
 data class XquareRequest(
-    val userId: String,
+    val accountId: String,
     val password: String
 )

--- a/src/main/kotlin/dsm/pick2024/infrastructure/feign/client/dto/response/XquareResponse.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/feign/client/dto/response/XquareResponse.kt
@@ -14,5 +14,6 @@ data class XquareResponse(
     val num: Int,
     val userRole: Role,
     val clubName: String? = null,
+    val profileImageUrl: String? = null,
     val birthDay: LocalDate
 )


### PR DESCRIPTION
<img width="773" alt="스크린샷 2024-08-06 오전 10 25 44" src="https://github.com/user-attachments/assets/5c308e7a-9fe6-4395-a2e8-ad6c8a597300">
close #274 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - `XquareResponse` 데이터 클래스에 사용자 프로필 이미지 URL을 나타내는 `profileImageUrl` 속성이 추가되었습니다.
  
- **변경 사항**
  - `XquareRequest` 데이터 클래스의 `userId` 속성이 `accountId`로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->