### PR TITLE
(#429) 시간표 업데이트 로직 추가🌈

### DIFF
--- a/src/main/kotlin/dsm/pick2024/domain/timetable/port/in/SaveTimetableUseCase.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/timetable/port/in/SaveTimetableUseCase.kt
@@ -1,5 +1,6 @@
 package dsm.pick2024.domain.timetable.port.`in`
 
 interface SaveTimetableUseCase {
-    fun saveTimetable()
+    fun saveTimetable(baseTime: Long)
+    fun saveNextWeekTimeTable()
 }

--- a/src/main/kotlin/dsm/pick2024/domain/timetable/port/in/SaveTimetableUseCase.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/timetable/port/in/SaveTimetableUseCase.kt
@@ -2,5 +2,4 @@ package dsm.pick2024.domain.timetable.port.`in`
 
 interface SaveTimetableUseCase {
     fun saveTimetable(baseTime: Long)
-    fun saveNextWeekTimeTable()
 }

--- a/src/main/kotlin/dsm/pick2024/domain/timetable/service/SaveTimetableService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/timetable/service/SaveTimetableService.kt
@@ -37,9 +37,6 @@ class SaveTimetableService(
         updatedTimetableEntities?.let { saveAllTimetablePort.saveAll(it) }
     }
 
-    override fun saveNextWeekTimeTable() {
-    }
-
     private fun updatedSubjectName(subjectName: String): String {
         val cleanName = subjectName.replace(Regex("[\\[\\(].*?[\\]\\)]|\\d|공통"), "")
 

--- a/src/main/kotlin/dsm/pick2024/domain/timetable/service/SaveTimetableService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/timetable/service/SaveTimetableService.kt
@@ -38,7 +38,6 @@ class SaveTimetableService(
     }
 
     override fun saveNextWeekTimeTable() {
-
     }
 
     private fun updatedSubjectName(subjectName: String): String {

--- a/src/main/kotlin/dsm/pick2024/domain/timetable/service/SaveTimetableService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/timetable/service/SaveTimetableService.kt
@@ -14,8 +14,8 @@ class SaveTimetableService(
 ) : SaveTimetableUseCase {
 
     @Transactional
-    override fun saveTimetable() {
-        val timetableEntities = neisTimetableFeignClientService.getNeisInfoToEntity()
+    override fun saveTimetable(baseTime: Long) {
+        val timetableEntities = neisTimetableFeignClientService.getNeisInfoToEntity(baseTime)
 
         val updatedTimetableEntities = timetableEntities?.mapNotNull { timetable ->
             val subject = updatedSubjectName(timetable.subjectName)
@@ -35,6 +35,10 @@ class SaveTimetableService(
         }?.toMutableList()
 
         updatedTimetableEntities?.let { saveAllTimetablePort.saveAll(it) }
+    }
+
+    override fun saveNextWeekTimeTable() {
+
     }
 
     private fun updatedSubjectName(subjectName: String): String {

--- a/src/main/kotlin/dsm/pick2024/infrastructure/feign/NeisTimetableFeignClientService.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/feign/NeisTimetableFeignClientService.kt
@@ -29,8 +29,8 @@ class NeisTimetableFeignClientService(
                 atptCode = NeisFeignClientRequestProperty.ATPT_OFCDC_CODE,
                 //요청을 보낸 날짜에 baseDay를 더한 후의 일주일 시간표를 변경한다.
 
-                startedYmd = runDay.with(java.time.DayOfWeek.MONDAY).toString().replace("-", ""),
-                endedYmd = runDay.with(java.time.DayOfWeek.MONDAY).plusDays(7).toString().replace("-", "")
+                startedYmd = runDay.with(java.time.DayOfWeek.SUNDAY).toString().replace("-", ""),
+                endedYmd = runDay.with(java.time.DayOfWeek.SUNDAY).plusDays(7).toString().replace("-", "")
             )
         val timetableJson =
             Gson().fromJson(

--- a/src/main/kotlin/dsm/pick2024/infrastructure/feign/NeisTimetableFeignClientService.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/feign/NeisTimetableFeignClientService.kt
@@ -16,10 +16,8 @@ class NeisTimetableFeignClientService(
     private val neisKey: String,
     private val neisFeignClient: NeisFeignClient
 ) {
-    fun getNeisInfoToEntity(baseDay : Long): MutableList<Timetable>? {
+    fun getNeisInfoToEntity(baseDay: Long): MutableList<Timetable>? {
         val runDay = LocalDate.now()
-        println(runDay.plusDays(baseDay).toString().replace("-", ""))
-        println(runDay.plusDays(baseDay+7).toString().replace("-", ""))
         val neisTimetableServiceInfoString =
             neisFeignClient.hisTimetable(
                 key = neisKey,
@@ -30,7 +28,7 @@ class NeisTimetableFeignClientService(
                 atptCode = NeisFeignClientRequestProperty.ATPT_OFCDC_CODE,
                 //요청을 보낸 날짜에 baseDay를 더한 후의 일주일 시간표를 변경한다.
                 startedYmd = runDay.plusDays(baseDay).toString().replace("-", ""),
-                endedYmd = runDay.plusDays(baseDay+7).toString().replace("-", "")
+                endedYmd = runDay.plusDays(baseDay + 7).toString().replace("-", "")
             )
         val timetableJson =
             Gson().fromJson(

--- a/src/main/kotlin/dsm/pick2024/infrastructure/feign/NeisTimetableFeignClientService.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/feign/NeisTimetableFeignClientService.kt
@@ -16,9 +16,10 @@ class NeisTimetableFeignClientService(
     private val neisKey: String,
     private val neisFeignClient: NeisFeignClient
 ) {
-    fun getNeisInfoToEntity(): MutableList<Timetable>? {
+    fun getNeisInfoToEntity(baseDay : Long): MutableList<Timetable>? {
         val runDay = LocalDate.now()
-
+        println(runDay.plusDays(baseDay).toString().replace("-", ""))
+        println(runDay.plusDays(baseDay+7).toString().replace("-", ""))
         val neisTimetableServiceInfoString =
             neisFeignClient.hisTimetable(
                 key = neisKey,
@@ -27,8 +28,9 @@ class NeisTimetableFeignClientService(
                 pageSize = NeisFeignClientRequestProperty.PAGE_SIZE,
                 schoolCode = NeisFeignClientRequestProperty.SD_SCHUL_CODE,
                 atptCode = NeisFeignClientRequestProperty.ATPT_OFCDC_CODE,
-                startedYmd = runDay.withDayOfMonth(runDay.dayOfMonth).toString().replace("-", ""),
-                endedYmd = runDay.withDayOfMonth(runDay.dayOfMonth).plusDays(7).toString().replace("-", "")
+                //요청을 보낸 날짜에 baseDay를 더한 후의 일주일 시간표를 변경한다.
+                startedYmd = runDay.plusDays(baseDay).toString().replace("-", ""),
+                endedYmd = runDay.plusDays(baseDay+7).toString().replace("-", "")
             )
         val timetableJson =
             Gson().fromJson(

--- a/src/main/kotlin/dsm/pick2024/infrastructure/feign/NeisTimetableFeignClientService.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/feign/NeisTimetableFeignClientService.kt
@@ -17,7 +17,8 @@ class NeisTimetableFeignClientService(
     private val neisFeignClient: NeisFeignClient
 ) {
     fun getNeisInfoToEntity(baseDay: Long): MutableList<Timetable>? {
-        val runDay = LocalDate.now()
+        val runDay = LocalDate.now().plusDays(baseDay)
+
         val neisTimetableServiceInfoString =
             neisFeignClient.hisTimetable(
                 key = neisKey,
@@ -28,8 +29,8 @@ class NeisTimetableFeignClientService(
                 atptCode = NeisFeignClientRequestProperty.ATPT_OFCDC_CODE,
                 //요청을 보낸 날짜에 baseDay를 더한 후의 일주일 시간표를 변경한다.
 
-                startedYmd = runDay.plusDays(baseDay).toString().replace("-", ""),
-                endedYmd = runDay.plusDays(baseDay + 7).toString().replace("-", "")
+                startedYmd = runDay.with(java.time.DayOfWeek.MONDAY).toString().replace("-", ""),
+                endedYmd = runDay.with(java.time.DayOfWeek.MONDAY).plusDays(7).toString().replace("-", "")
             )
         val timetableJson =
             Gson().fromJson(

--- a/src/main/kotlin/dsm/pick2024/infrastructure/feign/NeisTimetableFeignClientService.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/feign/NeisTimetableFeignClientService.kt
@@ -27,6 +27,7 @@ class NeisTimetableFeignClientService(
                 schoolCode = NeisFeignClientRequestProperty.SD_SCHUL_CODE,
                 atptCode = NeisFeignClientRequestProperty.ATPT_OFCDC_CODE,
                 //요청을 보낸 날짜에 baseDay를 더한 후의 일주일 시간표를 변경한다.
+
                 startedYmd = runDay.plusDays(baseDay).toString().replace("-", ""),
                 endedYmd = runDay.plusDays(baseDay + 7).toString().replace("-", "")
             )

--- a/src/main/kotlin/dsm/pick2024/infrastructure/schedule/ScheduleService.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/schedule/ScheduleService.kt
@@ -51,7 +51,7 @@ class ScheduleService(
     @Scheduled(cron = "0 0 2 * * 6", zone = "Asia/Seoul")
     fun saveNextWeekTimeTable() {
         deleteTimetablePort.deleteAll()
-        saveTimetableUseCase.saveTimetable(2)
+        saveTimetableUseCase.saveTimetable(3)
     }
 
     @Scheduled(cron = "0 0 8 * * ?")

--- a/src/main/kotlin/dsm/pick2024/infrastructure/schedule/ScheduleService.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/schedule/ScheduleService.kt
@@ -45,7 +45,13 @@ class ScheduleService(
     @Scheduled(cron = "0 0 6-23 * * 1-5", zone = "Asia/Seoul")
     fun saveTimetable() {
         deleteTimetablePort.deleteAll()
-        saveTimetableUseCase.saveTimetable()
+        saveTimetableUseCase.saveTimetable(0)
+    }
+
+    @Scheduled(cron = "0 0 2 * * 6", zone = "Asia/Seoul")
+    fun saveNextWeekTimeTable() {
+        deleteTimetablePort.deleteAll()
+        saveTimetableUseCase.saveTimetable(2)
     }
 
     @Scheduled(cron = "0 0 8 * * ?")


### PR DESCRIPTION
기존 로직: 현재 날짜를 기준으로 일주일 치 시간표를 업데이트
바뀐 로직: 현재 날짜 + baseDay를 기준으로 일주일 치 업데이트

saveTimetable은 baseDay를 0으로 설정해 원래 로직대로 돌아갑니다.
(new)saveNextWeekTimeTable를 토요일 오전 2시 마다 이벤트를 발생 시켜 baseDay를 2로 설정해 이틀 뒤인 다음주 월요일부터 금요일까지의 시간표를 업데이트합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - 시간표 저장 기능이 개선되어, 이제 기준 시간을 입력받아 보다 정확하게 시간표를 관리할 수 있습니다.
  - 매주 토요일 새벽에 자동으로 다음 주 시간표를 갱신하는 기능이 추가되었습니다.
- **Enhancements**
  - 스케줄링 및 날짜 계산 로직이 강화되어 시간표 업데이트의 신뢰성과 정밀도가 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->