### PR TITLE
(#432) neis 시간표 정상화

### DIFF
--- a/src/main/kotlin/dsm/pick2024/infrastructure/feign/NeisTimetableFeignClientService.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/feign/NeisTimetableFeignClientService.kt
@@ -18,7 +18,6 @@ class NeisTimetableFeignClientService(
 ) {
     fun getNeisInfoToEntity(baseDay: Long): MutableList<Timetable>? {
         val runDay = LocalDate.now().plusDays(baseDay)
-
         val neisTimetableServiceInfoString =
             neisFeignClient.hisTimetable(
                 key = neisKey,
@@ -27,10 +26,9 @@ class NeisTimetableFeignClientService(
                 pageSize = NeisFeignClientRequestProperty.PAGE_SIZE,
                 schoolCode = NeisFeignClientRequestProperty.SD_SCHUL_CODE,
                 atptCode = NeisFeignClientRequestProperty.ATPT_OFCDC_CODE,
-                //요청을 보낸 날짜에 baseDay를 더한 후의 일주일 시간표를 변경한다.
-
-                startedYmd = runDay.with(java.time.DayOfWeek.SUNDAY).toString().replace("-", ""),
-                endedYmd = runDay.with(java.time.DayOfWeek.SUNDAY).plusDays(7).toString().replace("-", "")
+                //runDay + baseDay 날짜의 전주 일요일 ~ 이번주 일요일의 시간표를 변경한다.
+                startedYmd = runDay.with(java.time.DayOfWeek.SUNDAY).minusDays(7).toString().replace("-", ""),
+                endedYmd = runDay.with(java.time.DayOfWeek.SUNDAY).toString().replace("-", "")
             )
         val timetableJson =
             Gson().fromJson(

--- a/src/main/kotlin/dsm/pick2024/infrastructure/schedule/ScheduleService.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/schedule/ScheduleService.kt
@@ -51,7 +51,7 @@ class ScheduleService(
     @Scheduled(cron = "0 0 2 * * 6", zone = "Asia/Seoul")
     fun saveNextWeekTimeTable() {
         deleteTimetablePort.deleteAll()
-        saveTimetableUseCase.saveTimetable(3)
+        saveTimetableUseCase.saveTimetable(4)
     }
 
     @Scheduled(cron = "0 0 8 * * ?")


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/076b95f9-36d2-4b90-937f-b9d7227c062f)
일요일이 주의 첫 날이라고 착각해 MONDAY를 SUNDAY로 바로 고치는 과정에서 이슈가 발생한 것 같습니다.

현재 날짜에서 7일 뺀 후 저번주 일요일을 찾아 저번주 일요일부터 이번주 일요일까지로 로직을 변경했습니다.
![image](https://github.com/user-attachments/assets/ad38d277-ea97-4f0f-a3c8-bad3f5b777a5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 타임테이블 날짜 범위 계산이 조정되어, 이전 일요일부터 현재 일요일까지의 주간 데이터가 올바르게 표시됩니다.
	- 스케줄링 처리 파라미터가 업데이트되어 타임테이블 저장 시 보다 정확한 데이터 처리가 이루어집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->