### PR TITLE
445 fcm error

### DIFF
--- a/src/main/kotlin/dsm/pick2024/domain/application/service/ChangeApplicationStatusService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/application/service/ChangeApplicationStatusService.kt
@@ -11,6 +11,8 @@ import dsm.pick2024.domain.application.port.out.DeleteApplicationPort
 import dsm.pick2024.domain.application.port.out.QueryApplicationPort
 import dsm.pick2024.domain.application.port.out.SaveApplicationPort
 import dsm.pick2024.domain.application.presentation.dto.request.ApplicationStatusRequest
+import dsm.pick2024.domain.application.service.processor.ApplicationApprovalProcessor
+import dsm.pick2024.domain.application.service.processor.ApplicationRejectionProcessor
 import dsm.pick2024.domain.applicationstory.domain.ApplicationStory
 import dsm.pick2024.domain.applicationstory.enums.Type
 import dsm.pick2024.domain.applicationstory.port.out.SaveAllApplicationStoryPort
@@ -28,99 +30,25 @@ import java.util.UUID
 @Service
 class ChangeApplicationStatusService(
     private val adminFacadeUseCase: AdminFacadeUseCase,
-    private val queryApplicationPort: QueryApplicationPort,
-    private val saveApplicationPort: SaveApplicationPort,
-    private val applicationStorySaveAllPort: SaveAllApplicationStoryPort,
-    private val deleteApplicationPort: DeleteApplicationPort,
-    private val saveAttendancePort: SaveAttendancePort,
-    private val queryAttendancePort: QueryAttendancePort,
-    private val attendanceService: AttendanceService,
-    private val eventPublisher: ApplicationEventPublisher,
-    private val sendMessageUseCase: FcmSendMessageUseCase,
     private val userFacadeUseCase: UserFacadeUseCase,
-    private val applicationFinderUseCase: ApplicationFinderUseCase
+    private val applicationFinderUseCase: ApplicationFinderUseCase,
+    private val approvalProcessor: ApplicationApprovalProcessor,
+    private val rejectionProcessor: ApplicationRejectionProcessor
 ) : ChangeApplicationStatusUseCase {
 
     @Transactional
     override fun changeStatusApplication(request: ApplicationStatusRequest) {
         val admin = adminFacadeUseCase.currentAdmin()
-        val applications = request.idList.map { findApplicationById(it) }
+        val applications = request.idList.map { applicationFinderUseCase.findByIdOrThrow(it) }
+
         val deviceTokens = applications.mapNotNull {
-            userFacadeUseCase.getUserByXquareId(
-                it.userId
-            ).deviceToken
+            userFacadeUseCase.getUserByXquareId(it.userId).deviceToken
         }.filter { it.isNotBlank() }
 
-        when (request.status) {
-            Status.NO -> {
-                sendMessageUseCase.execute(deviceTokens, "외출 신청 반려 안내", "${admin.name} 선생님이 외출 신청을 반려하셨습니다.")
-            }
-            Status.OK -> {
-                sendMessageUseCase.execute(deviceTokens, "외출 신청 승인 안내", "${admin.name} 선생님이 외출 신청을 승인하셨습니다.")
-            }
-            else -> {
-            }
-        }
-
-        if (request.status == Status.NO) {
-            handleStatusNo(request.idList)
+        if (request.status == Status.OK) {
+            approvalProcessor.process(applications, admin.name, deviceTokens)
         } else {
-            val updateApplicationList = applications.map {
-                updateApplication(it, admin.name)
-            }
-
-            val applicationStory = updateApplicationList.map { it ->
-                createApplicationStory(it)
-            }
-
-            val attendance = updateApplicationList.map { it ->
-                val attendanceId = queryAttendancePort.findByUserId(it.userId)
-                attendanceService.updateAttendanceToApplication(it.start, it.end!!, it.applicationType, attendanceId!!)
-            }.toMutableList()
-
-            saveApplicationPort.saveAll(updateApplicationList)
-            applicationStorySaveAllPort.saveAll(applicationStory)
-            saveAttendancePort.saveAll(attendance)
-            eventPublisher.publishEvent(
-                ChangeStatusRequest(EventTopic.HANDLE_EVENT, updateApplicationList.map { it.userId })
-            )
+            rejectionProcessor.process(applications, admin.name, deviceTokens)
         }
-    }
-
-    private fun handleStatusNo(idList: List<UUID>) {
-        val applicationList = idList.map { findApplicationById(it) }
-        eventPublisher.publishEvent(ChangeStatusRequest(this, applicationList.map { it.userId }))
-        idList.map { id ->
-            val application = findApplicationById(id)
-            deleteApplicationPort.deleteByIdAndApplicationKind(application.id!!, ApplicationKind.APPLICATION)
-        }
-    }
-
-    private fun findApplicationById(id: UUID): Application {
-        return applicationFinderUseCase.findByIdOrThrow(id)
-    }
-
-    private fun updateApplication(application: Application, adminName: String): Application {
-        return application.copy(
-            teacherName = adminName,
-            status = Status.OK
-        )
-    }
-
-    private fun createApplicationStory(application: Application): ApplicationStory {
-        val startAndEnd = attendanceService.translateApplication(
-            application.start,
-            application.end!!,
-            application.applicationType
-        )
-        return ApplicationStory(
-            reason = application.reason,
-            userName = application.userName,
-            start = startAndEnd.first(),
-            end = startAndEnd.last(),
-            date = application.date,
-            type = Type.APPLICATION,
-            userId = application.userId
-        )
     }
 }

--- a/src/main/kotlin/dsm/pick2024/domain/application/service/ChangeApplicationStatusService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/application/service/ChangeApplicationStatusService.kt
@@ -1,8 +1,6 @@
 package dsm.pick2024.domain.application.service
 
 import dsm.pick2024.domain.admin.port.`in`.AdminFacadeUseCase
-import dsm.pick2024.domain.application.enums.ApplicationKind
-import dsm.pick2024.domain.application.enums.ApplicationType
 import dsm.pick2024.domain.application.enums.Status
 import dsm.pick2024.domain.application.exception.AlreadyApplyingForPicnicException
 import dsm.pick2024.domain.application.port.`in`.ApplicationFinderUseCase
@@ -27,7 +25,7 @@ class ChangeApplicationStatusService(
     override fun changeStatusApplication(request: ApplicationStatusRequest) {
         val admin = adminFacadeUseCase.currentAdmin()
         val applications = request.idList.map { applicationFinderUseCase.findByIdOrThrow(it) }
-        applications.forEach { application -> if(application.status != Status.QUIET) throw AlreadyApplyingForPicnicException }
+        applications.forEach { a -> if (a.status != Status.QUIET) throw AlreadyApplyingForPicnicException }
 
         val deviceTokens = applications.mapNotNull {
             userFacadeUseCase.getUserByXquareId(it.userId).deviceToken

--- a/src/main/kotlin/dsm/pick2024/domain/application/service/ChangeApplicationStatusService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/application/service/ChangeApplicationStatusService.kt
@@ -1,7 +1,10 @@
 package dsm.pick2024.domain.application.service
 
 import dsm.pick2024.domain.admin.port.`in`.AdminFacadeUseCase
+import dsm.pick2024.domain.application.enums.ApplicationKind
+import dsm.pick2024.domain.application.enums.ApplicationType
 import dsm.pick2024.domain.application.enums.Status
+import dsm.pick2024.domain.application.exception.AlreadyApplyingForPicnicException
 import dsm.pick2024.domain.application.port.`in`.ApplicationFinderUseCase
 import dsm.pick2024.domain.application.port.`in`.ChangeApplicationStatusUseCase
 import dsm.pick2024.domain.application.presentation.dto.request.ApplicationStatusRequest
@@ -24,6 +27,7 @@ class ChangeApplicationStatusService(
     override fun changeStatusApplication(request: ApplicationStatusRequest) {
         val admin = adminFacadeUseCase.currentAdmin()
         val applications = request.idList.map { applicationFinderUseCase.findByIdOrThrow(it) }
+        applications.forEach { application -> if(application.status != Status.QUIET) throw AlreadyApplyingForPicnicException }
 
         val deviceTokens = applications.mapNotNull {
             userFacadeUseCase.getUserByXquareId(it.userId).deviceToken

--- a/src/main/kotlin/dsm/pick2024/domain/application/service/ChangeApplicationStatusService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/application/service/ChangeApplicationStatusService.kt
@@ -1,31 +1,15 @@
 package dsm.pick2024.domain.application.service
 
 import dsm.pick2024.domain.admin.port.`in`.AdminFacadeUseCase
-import dsm.pick2024.domain.application.domain.Application
-import dsm.pick2024.domain.application.enums.ApplicationKind
 import dsm.pick2024.domain.application.enums.Status
-import dsm.pick2024.domain.event.dto.ChangeStatusRequest
 import dsm.pick2024.domain.application.port.`in`.ApplicationFinderUseCase
 import dsm.pick2024.domain.application.port.`in`.ChangeApplicationStatusUseCase
-import dsm.pick2024.domain.application.port.out.DeleteApplicationPort
-import dsm.pick2024.domain.application.port.out.QueryApplicationPort
-import dsm.pick2024.domain.application.port.out.SaveApplicationPort
 import dsm.pick2024.domain.application.presentation.dto.request.ApplicationStatusRequest
 import dsm.pick2024.domain.application.service.processor.ApplicationApprovalProcessor
 import dsm.pick2024.domain.application.service.processor.ApplicationRejectionProcessor
-import dsm.pick2024.domain.applicationstory.domain.ApplicationStory
-import dsm.pick2024.domain.applicationstory.enums.Type
-import dsm.pick2024.domain.applicationstory.port.out.SaveAllApplicationStoryPort
-import dsm.pick2024.domain.attendance.domain.service.AttendanceService
-import dsm.pick2024.domain.attendance.port.out.QueryAttendancePort
-import dsm.pick2024.domain.attendance.port.out.SaveAttendancePort
-import dsm.pick2024.domain.event.enums.EventTopic
-import dsm.pick2024.domain.fcm.port.`in`.FcmSendMessageUseCase
 import dsm.pick2024.domain.user.port.`in`.UserFacadeUseCase
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.UUID
 
 @Service
 class ChangeApplicationStatusService(

--- a/src/main/kotlin/dsm/pick2024/domain/application/service/processor/ApplicationApprovalProcessor.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/application/service/processor/ApplicationApprovalProcessor.kt
@@ -1,0 +1,64 @@
+package dsm.pick2024.domain.application.service.processor
+
+import dsm.pick2024.domain.application.domain.Application
+import dsm.pick2024.domain.application.enums.Status
+import dsm.pick2024.domain.application.port.out.SaveApplicationPort
+import dsm.pick2024.domain.applicationstory.domain.ApplicationStory
+import dsm.pick2024.domain.applicationstory.enums.Type
+import dsm.pick2024.domain.applicationstory.port.out.SaveAllApplicationStoryPort
+import dsm.pick2024.domain.attendance.domain.service.AttendanceService
+import dsm.pick2024.domain.attendance.port.out.QueryAttendancePort
+import dsm.pick2024.domain.attendance.port.out.SaveAttendancePort
+import dsm.pick2024.domain.event.dto.ChangeStatusRequest
+import dsm.pick2024.domain.event.enums.EventTopic
+import dsm.pick2024.domain.fcm.port.`in`.FcmSendMessageUseCase
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class ApplicationApprovalProcessor(
+    private val saveApplicationPort: SaveApplicationPort,
+    private val applicationStorySaveAllPort: SaveAllApplicationStoryPort,
+    private val queryAttendancePort: QueryAttendancePort,
+    private val saveAttendancePort: SaveAttendancePort,
+    private val attendanceService: AttendanceService,
+    private val eventPublisher: ApplicationEventPublisher,
+    sendMessageUseCase: FcmSendMessageUseCase
+) : ApplicationStatusProcessor(sendMessageUseCase) {
+
+    override fun process(applications: List<Application>, adminName: String, deviceTokens: List<String>) {
+        val updateApplications = applications.map { it.copy(teacherName = adminName, status = Status.OK) }
+
+        val applicationStories = updateApplications.map {
+            val (start, end) = attendanceService.translateApplication(it.start, it.end!!, it.applicationType)
+            ApplicationStory(
+                reason = it.reason,
+                userName = it.userName,
+                start = start,
+                end = end,
+                date = it.date,
+                type = Type.APPLICATION,
+                userId = it.userId
+            )
+        }
+
+        val attendances = updateApplications.map {
+            val attendanceId = queryAttendancePort.findByUserId(it.userId)
+            attendanceService.updateAttendanceToApplication(it.start, it.end!!, it.applicationType, attendanceId!!)
+        }
+
+        saveApplicationPort.saveAll(updateApplications)
+        applicationStorySaveAllPort.saveAll(applicationStories)
+        saveAttendancePort.saveAll(attendances)
+
+        sendNotification(
+            title = "외출 신청 승인 안내",
+            message = "$adminName 선생님이 외출 신청을 승인하셨습니다.",
+            deviceTokens = deviceTokens
+        )
+
+        eventPublisher.publishEvent(
+            ChangeStatusRequest(EventTopic.HANDLE_EVENT, updateApplications.map { it.userId })
+        )
+    }
+}

--- a/src/main/kotlin/dsm/pick2024/domain/application/service/processor/ApplicationRejectionProcessor.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/application/service/processor/ApplicationRejectionProcessor.kt
@@ -1,0 +1,31 @@
+package dsm.pick2024.domain.application.service.processor
+
+import dsm.pick2024.domain.application.domain.Application
+import dsm.pick2024.domain.application.enums.ApplicationKind
+import dsm.pick2024.domain.application.port.out.DeleteApplicationPort
+import dsm.pick2024.domain.event.dto.ChangeStatusRequest
+import dsm.pick2024.domain.fcm.port.`in`.FcmSendMessageUseCase
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class ApplicationRejectionProcessor(
+    private val deleteApplicationPort: DeleteApplicationPort,
+    private val eventPublisher: ApplicationEventPublisher,
+    sendMessageUseCase: FcmSendMessageUseCase
+) : ApplicationStatusProcessor(sendMessageUseCase) {
+
+    override fun process(applications: List<Application>, adminName: String, deviceTokens: List<String>) {
+        applications.forEach {
+            deleteApplicationPort.deleteByIdAndApplicationKind(it.id!!, ApplicationKind.APPLICATION)
+        }
+
+        sendNotification(
+            title = "외출 신청 반려 안내",
+            message = "$adminName 선생님이 외출 신청을 반려하셨습니다.",
+            deviceTokens = deviceTokens
+        )
+
+        eventPublisher.publishEvent(ChangeStatusRequest(this, applications.map { it.userId }))
+    }
+}

--- a/src/main/kotlin/dsm/pick2024/domain/application/service/processor/ApplicationStatusProcessor.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/application/service/processor/ApplicationStatusProcessor.kt
@@ -1,0 +1,14 @@
+package dsm.pick2024.domain.application.service.processor
+
+import dsm.pick2024.domain.application.domain.Application
+import dsm.pick2024.domain.fcm.port.`in`.FcmSendMessageUseCase
+
+abstract class ApplicationStatusProcessor(
+    private val sendMessageUseCase: FcmSendMessageUseCase
+) {
+    abstract fun process(applications: List<Application>, adminName: String, deviceTokens: List<String>)
+
+    protected fun sendNotification(title: String, message: String, deviceTokens: List<String>) {
+        sendMessageUseCase.execute(deviceTokens, title, message)
+    }
+}

--- a/src/main/kotlin/dsm/pick2024/domain/attendance/persistence/AttendancePersistenceAdapter.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/attendance/persistence/AttendancePersistenceAdapter.kt
@@ -18,7 +18,7 @@ class AttendancePersistenceAdapter(
 ) : AttendancePort {
 
     override fun save(attendance: Attendance) = attendanceJpaRepository.save(attendanceMapper.toEntity(attendance))
-    override fun saveAll(attendance: MutableList<Attendance>) {
+    override fun saveAll(attendance: List<Attendance>) {
         val entities = attendance.map { attendanceMapper.toEntity(it) }
         attendanceJpaRepository.saveAll(entities)
     }

--- a/src/main/kotlin/dsm/pick2024/domain/attendance/persistence/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/attendance/persistence/repository/AttendanceRepository.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 interface AttendanceRepository : Repository<AttendanceJpaEntity, UUID> {
     fun save(entity: AttendanceJpaEntity)
 
-    fun saveAll(entity: List<AttendanceJpaEntity>)
+    fun saveAll(entity: Iterable<AttendanceJpaEntity>)
 
     fun findByUserId(userId: UUID): AttendanceJpaEntity
 

--- a/src/main/kotlin/dsm/pick2024/domain/attendance/persistence/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/attendance/persistence/repository/AttendanceRepository.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 interface AttendanceRepository : Repository<AttendanceJpaEntity, UUID> {
     fun save(entity: AttendanceJpaEntity)
 
-    fun saveAll(entity: Iterable<AttendanceJpaEntity>)
+    fun saveAll(entity: List<AttendanceJpaEntity>)
 
     fun findByUserId(userId: UUID): AttendanceJpaEntity
 

--- a/src/main/kotlin/dsm/pick2024/domain/attendance/port/out/SaveAttendancePort.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/attendance/port/out/SaveAttendancePort.kt
@@ -3,6 +3,6 @@ package dsm.pick2024.domain.attendance.port.out
 import dsm.pick2024.domain.attendance.domain.Attendance
 
 interface SaveAttendancePort {
-    fun saveAll(attendance: MutableList<Attendance>)
+    fun saveAll(attendance: List<Attendance>)
     fun save(attendance: Attendance)
 }

--- a/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/ChangeEarlyReturnStatusService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/ChangeEarlyReturnStatusService.kt
@@ -2,28 +2,14 @@ package dsm.pick2024.domain.earlyreturn.service
 
 import dsm.pick2024.domain.admin.port.`in`.AdminFacadeUseCase
 import dsm.pick2024.domain.application.domain.Application
-import dsm.pick2024.domain.application.enums.ApplicationKind
-import dsm.pick2024.domain.application.enums.ApplicationType
 import dsm.pick2024.domain.application.enums.Status
 import dsm.pick2024.domain.application.exception.AlreadyApplyingForPicnicException
-import dsm.pick2024.domain.event.dto.ChangeStatusRequest
 import dsm.pick2024.domain.application.port.`in`.ApplicationFinderUseCase
-import dsm.pick2024.domain.application.port.out.DeleteApplicationPort
-import dsm.pick2024.domain.application.port.out.QueryApplicationPort
-import dsm.pick2024.domain.application.port.out.SaveApplicationPort
-import dsm.pick2024.domain.applicationstory.domain.ApplicationStory
-import dsm.pick2024.domain.applicationstory.enums.Type
-import dsm.pick2024.domain.applicationstory.port.out.SaveAllApplicationStoryPort
-import dsm.pick2024.domain.attendance.domain.service.AttendanceService
-import dsm.pick2024.domain.attendance.port.out.QueryAttendancePort
-import dsm.pick2024.domain.attendance.port.out.SaveAttendancePort
 import dsm.pick2024.domain.earlyreturn.port.`in`.ChangeEarlyReturnStatusUseCase
 import dsm.pick2024.domain.earlyreturn.presentation.dto.request.StatusEarlyReturnRequest
 import dsm.pick2024.domain.earlyreturn.service.processor.EarlyReturnApprovalProcessor
 import dsm.pick2024.domain.earlyreturn.service.processor.EarlyReturnRejectionProcessor
-import dsm.pick2024.domain.fcm.port.`in`.FcmSendMessageUseCase
 import dsm.pick2024.domain.user.port.`in`.UserFacadeUseCase
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -49,7 +35,7 @@ class ChangeEarlyReturnStatusService(
             ).deviceToken
         }.filter { it.isNotBlank() }
 
-        if (request.status == Status.OK){
+        if (request.status == Status.OK) {
             earlyReturnApprovalProcessor.process(applications, admin.name, deviceTokens)
         } else {
             earlyReturnRejectionProcessor.process(applications, admin.name, deviceTokens)
@@ -58,5 +44,4 @@ class ChangeEarlyReturnStatusService(
     private fun findApplicationById(id: UUID): Application {
         return applicationFinderUseCase.findByIdOrThrow(id)
     }
-
 }

--- a/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/ChangeEarlyReturnStatusService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/ChangeEarlyReturnStatusService.kt
@@ -5,6 +5,7 @@ import dsm.pick2024.domain.application.domain.Application
 import dsm.pick2024.domain.application.enums.ApplicationKind
 import dsm.pick2024.domain.application.enums.ApplicationType
 import dsm.pick2024.domain.application.enums.Status
+import dsm.pick2024.domain.application.exception.AlreadyApplyingForPicnicException
 import dsm.pick2024.domain.event.dto.ChangeStatusRequest
 import dsm.pick2024.domain.application.port.`in`.ApplicationFinderUseCase
 import dsm.pick2024.domain.application.port.out.DeleteApplicationPort
@@ -18,6 +19,8 @@ import dsm.pick2024.domain.attendance.port.out.QueryAttendancePort
 import dsm.pick2024.domain.attendance.port.out.SaveAttendancePort
 import dsm.pick2024.domain.earlyreturn.port.`in`.ChangeEarlyReturnStatusUseCase
 import dsm.pick2024.domain.earlyreturn.presentation.dto.request.StatusEarlyReturnRequest
+import dsm.pick2024.domain.earlyreturn.service.processor.EarlyReturnApprovalProcessor
+import dsm.pick2024.domain.earlyreturn.service.processor.EarlyReturnRejectionProcessor
 import dsm.pick2024.domain.fcm.port.`in`.FcmSendMessageUseCase
 import dsm.pick2024.domain.user.port.`in`.UserFacadeUseCase
 import org.springframework.context.ApplicationEventPublisher
@@ -28,23 +31,17 @@ import java.util.UUID
 @Service
 class ChangeEarlyReturnStatusService(
     private val adminFacadeUseCase: AdminFacadeUseCase,
-    private val saveApplicationPort: SaveApplicationPort,
-    private val queryApplicationPort: QueryApplicationPort,
-    private val applicationStorySaveAllPort: SaveAllApplicationStoryPort,
-    private val deleteApplicationPort: DeleteApplicationPort,
-    private val saveAttendancePort: SaveAttendancePort,
-    private val queryAttendancePort: QueryAttendancePort,
-    private val attendanceService: AttendanceService,
-    private val eventPublisher: ApplicationEventPublisher,
-    private val fcmSendMessageUseCase: FcmSendMessageUseCase,
     private val userFacadeUseCase: UserFacadeUseCase,
-    private val applicationFinderUseCase: ApplicationFinderUseCase
+    private val applicationFinderUseCase: ApplicationFinderUseCase,
+    private val earlyReturnApprovalProcessor: EarlyReturnApprovalProcessor,
+    private val earlyReturnRejectionProcessor: EarlyReturnRejectionProcessor
 ) : ChangeEarlyReturnStatusUseCase {
 
     @Transactional
     override fun statusEarlyReturn(request: StatusEarlyReturnRequest) {
         val admin = adminFacadeUseCase.currentAdmin()
         val applications = request.idList.map { findApplicationById(it) }
+        applications.forEach { a -> if (a.status != Status.QUIET) throw AlreadyApplyingForPicnicException }
 
         val deviceTokens = applications.mapNotNull {
             userFacadeUseCase.getUserByXquareId(
@@ -52,69 +49,14 @@ class ChangeEarlyReturnStatusService(
             ).deviceToken
         }.filter { it.isNotBlank() }
 
-        when (request.status) {
-            Status.NO -> {
-                fcmSendMessageUseCase.execute(deviceTokens, "조귀귀가 신청 반려 안내", "${admin.name} 선생님이 조귀귀가 신청을 반려하셨습니다.")
-            }
-            Status.OK -> {
-                fcmSendMessageUseCase.execute(deviceTokens, "조귀귀가 신청 승인 안내", "${admin.name} 선생님이 조귀귀가 신청을 승인하셨습니다.")
-            }
-            else -> {
-            }
-        }
-
-        if (request.status == Status.NO) {
-            handleStatusNo(request.idList)
-            return
-        }
-
-        val updateEarlyReturnList = applications.map {
-            updateEarlyReturn(it, admin.name)
-        }
-
-        val applicationStory = updateEarlyReturnList.map { earlyReturn ->
-            createApplicationStory(earlyReturn)
-        }
-
-        val attendances = updateEarlyReturnList.map { it ->
-            val attendanceId = queryAttendancePort.findByUserId(it.userId)
-            attendanceService.updateAttendanceToEarlyReturn(it.start, attendanceId!!)
-        }.toMutableList()
-
-        saveApplicationPort.saveAll(updateEarlyReturnList)
-        applicationStorySaveAllPort.saveAll(applicationStory)
-        saveAttendancePort.saveAll(attendances)
-        eventPublisher.publishEvent(ChangeStatusRequest(this, updateEarlyReturnList.map { it.userId }))
-    }
-
-    private fun handleStatusNo(idList: List<UUID>) {
-        eventPublisher.publishEvent(ChangeStatusRequest(this, idList.map { findApplicationById(it).userId }))
-        idList.map { id ->
-            val application = findApplicationById(id)
-            deleteApplicationPort.deleteByIdAndApplicationKind(application.id!!, ApplicationKind.APPLICATION)
+        if (request.status == Status.OK){
+            earlyReturnApprovalProcessor.process(applications, admin.name, deviceTokens)
+        } else {
+            earlyReturnRejectionProcessor.process(applications, admin.name, deviceTokens)
         }
     }
-
-    private fun updateEarlyReturn(application: Application, adminName: String): Application {
-        return application.copy(
-            teacherName = adminName,
-            status = Status.OK
-        )
-    }
-
     private fun findApplicationById(id: UUID): Application {
         return applicationFinderUseCase.findByIdOrThrow(id)
     }
 
-    private fun createApplicationStory(application: Application): ApplicationStory {
-        val start = attendanceService.translateApplication(application.start, null, ApplicationType.TIME)
-        return ApplicationStory(
-            reason = application.reason,
-            userName = application.userName,
-            start = start.first(),
-            date = application.date,
-            type = Type.EARLY_RETURN,
-            userId = application.userId
-        )
-    }
 }

--- a/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/processor/EarlyReturnApprovalProcessor.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/processor/EarlyReturnApprovalProcessor.kt
@@ -1,0 +1,65 @@
+package dsm.pick2024.domain.earlyreturn.service.processor
+
+import dsm.pick2024.domain.admin.port.`in`.AdminFacadeUseCase
+import dsm.pick2024.domain.application.domain.Application
+import dsm.pick2024.domain.application.enums.ApplicationType
+import dsm.pick2024.domain.application.enums.Status
+import dsm.pick2024.domain.application.port.`in`.ApplicationFinderUseCase
+import dsm.pick2024.domain.application.port.out.DeleteApplicationPort
+import dsm.pick2024.domain.application.port.out.QueryApplicationPort
+import dsm.pick2024.domain.application.port.out.SaveApplicationPort
+import dsm.pick2024.domain.applicationstory.domain.ApplicationStory
+import dsm.pick2024.domain.applicationstory.enums.Type
+import dsm.pick2024.domain.applicationstory.port.out.SaveAllApplicationStoryPort
+import dsm.pick2024.domain.attendance.domain.service.AttendanceService
+import dsm.pick2024.domain.attendance.port.out.QueryAttendancePort
+import dsm.pick2024.domain.attendance.port.out.SaveAttendancePort
+import dsm.pick2024.domain.event.dto.ChangeStatusRequest
+import dsm.pick2024.domain.fcm.port.`in`.FcmSendMessageUseCase
+import dsm.pick2024.domain.user.port.`in`.UserFacadeUseCase
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class EarlyReturnApprovalProcessor(
+    private val saveApplicationPort: SaveApplicationPort,
+    private val applicationStorySaveAllPort: SaveAllApplicationStoryPort,
+    private val saveAttendancePort: SaveAttendancePort,
+    private val queryAttendancePort: QueryAttendancePort,
+    private val attendanceService: AttendanceService,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val sendMessageUseCase: FcmSendMessageUseCase,
+    ):EarlyReturnStatusProcessor(sendMessageUseCase) {
+    override fun process(applications: List<Application>, adminName: String, deviceTokens: List<String>) {
+        val updateEarlyReturnList = applications.map {it.copy(teacherName = adminName, status = Status.OK)}
+
+        val applicationStory = updateEarlyReturnList.map { earlyReturn ->
+            createApplicationStory(earlyReturn)
+        }
+
+        sendNotification("조기귀가 신청 승인 안내", "$adminName 선생님이 조기귀가 신청을 승인하셨습니다.", deviceTokens)
+
+        val attendances = updateEarlyReturnList.map {
+            val attendanceId = queryAttendancePort.findByUserId(it.userId)
+            attendanceService.updateAttendanceToEarlyReturn(it.start, attendanceId!!)
+        }.toMutableList()
+
+        saveApplicationPort.saveAll(updateEarlyReturnList)
+        applicationStorySaveAllPort.saveAll(applicationStory)
+        saveAttendancePort.saveAll(attendances)
+        eventPublisher.publishEvent(ChangeStatusRequest(this, updateEarlyReturnList.map { it.userId }))
+    }
+
+    private fun createApplicationStory(application: Application): ApplicationStory {
+        val start = attendanceService.translateApplication(application.start, null, ApplicationType.TIME)
+        return ApplicationStory(
+            reason = application.reason,
+            userName = application.userName,
+            start = start.first(),
+            date = application.date,
+            type = Type.EARLY_RETURN,
+            userId = application.userId
+        )
+    }
+}

--- a/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/processor/EarlyReturnApprovalProcessor.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/processor/EarlyReturnApprovalProcessor.kt
@@ -1,12 +1,8 @@
 package dsm.pick2024.domain.earlyreturn.service.processor
 
-import dsm.pick2024.domain.admin.port.`in`.AdminFacadeUseCase
 import dsm.pick2024.domain.application.domain.Application
 import dsm.pick2024.domain.application.enums.ApplicationType
 import dsm.pick2024.domain.application.enums.Status
-import dsm.pick2024.domain.application.port.`in`.ApplicationFinderUseCase
-import dsm.pick2024.domain.application.port.out.DeleteApplicationPort
-import dsm.pick2024.domain.application.port.out.QueryApplicationPort
 import dsm.pick2024.domain.application.port.out.SaveApplicationPort
 import dsm.pick2024.domain.applicationstory.domain.ApplicationStory
 import dsm.pick2024.domain.applicationstory.enums.Type
@@ -16,7 +12,6 @@ import dsm.pick2024.domain.attendance.port.out.QueryAttendancePort
 import dsm.pick2024.domain.attendance.port.out.SaveAttendancePort
 import dsm.pick2024.domain.event.dto.ChangeStatusRequest
 import dsm.pick2024.domain.fcm.port.`in`.FcmSendMessageUseCase
-import dsm.pick2024.domain.user.port.`in`.UserFacadeUseCase
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import java.util.*
@@ -29,10 +24,10 @@ class EarlyReturnApprovalProcessor(
     private val queryAttendancePort: QueryAttendancePort,
     private val attendanceService: AttendanceService,
     private val eventPublisher: ApplicationEventPublisher,
-    private val sendMessageUseCase: FcmSendMessageUseCase,
-    ):EarlyReturnStatusProcessor(sendMessageUseCase) {
+    private val sendMessageUseCase: FcmSendMessageUseCase
+) : EarlyReturnStatusProcessor(sendMessageUseCase) {
     override fun process(applications: List<Application>, adminName: String, deviceTokens: List<String>) {
-        val updateEarlyReturnList = applications.map {it.copy(teacherName = adminName, status = Status.OK)}
+        val updateEarlyReturnList = applications.map { it.copy(teacherName = adminName, status = Status.OK) }
 
         val applicationStory = updateEarlyReturnList.map { earlyReturn ->
             createApplicationStory(earlyReturn)

--- a/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/processor/EarlyReturnRejectionProcessor.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/processor/EarlyReturnRejectionProcessor.kt
@@ -1,0 +1,27 @@
+package dsm.pick2024.domain.earlyreturn.service.processor
+
+import dsm.pick2024.domain.application.domain.Application
+import dsm.pick2024.domain.application.enums.ApplicationKind
+import dsm.pick2024.domain.application.port.out.DeleteApplicationPort
+import dsm.pick2024.domain.event.dto.ChangeStatusRequest
+import dsm.pick2024.domain.fcm.port.`in`.FcmSendMessageUseCase
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class EarlyReturnRejectionProcessor(
+    sendMessageUseCase: FcmSendMessageUseCase,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val deleteApplicationPort: DeleteApplicationPort,
+
+    ): EarlyReturnStatusProcessor(sendMessageUseCase){
+    override fun process(applications: List<Application>, adminName: String, deviceTokens: List<String>) {
+        applications.map {
+            deleteApplicationPort.deleteByIdAndApplicationKind(it.id!!, ApplicationKind.APPLICATION)
+        }
+
+        sendNotification("조기귀가 신청 반려 안내","$adminName 선생님께서 조기귀가 신청을 반려하였습니다. ",deviceTokens)
+
+        eventPublisher.publishEvent(ChangeStatusRequest(this, applications.map { it.userId }))
+    }
+}

--- a/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/processor/EarlyReturnRejectionProcessor.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/processor/EarlyReturnRejectionProcessor.kt
@@ -17,7 +17,7 @@ class EarlyReturnRejectionProcessor(
     ): EarlyReturnStatusProcessor(sendMessageUseCase){
     override fun process(applications: List<Application>, adminName: String, deviceTokens: List<String>) {
         applications.map {
-            deleteApplicationPort.deleteByIdAndApplicationKind(it.id!!, ApplicationKind.APPLICATION)
+            deleteApplicationPort.deleteByIdAndApplicationKind(it.id!!, ApplicationKind.EARLY_RETURN)
         }
 
         sendNotification("조기귀가 신청 반려 안내","$adminName 선생님께서 조기귀가 신청을 반려하였습니다. ",deviceTokens)

--- a/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/processor/EarlyReturnRejectionProcessor.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/processor/EarlyReturnRejectionProcessor.kt
@@ -12,15 +12,15 @@ import org.springframework.stereotype.Service
 class EarlyReturnRejectionProcessor(
     sendMessageUseCase: FcmSendMessageUseCase,
     private val eventPublisher: ApplicationEventPublisher,
-    private val deleteApplicationPort: DeleteApplicationPort,
+    private val deleteApplicationPort: DeleteApplicationPort
 
-    ): EarlyReturnStatusProcessor(sendMessageUseCase){
+) : EarlyReturnStatusProcessor(sendMessageUseCase) {
     override fun process(applications: List<Application>, adminName: String, deviceTokens: List<String>) {
         applications.map {
             deleteApplicationPort.deleteByIdAndApplicationKind(it.id!!, ApplicationKind.EARLY_RETURN)
         }
 
-        sendNotification("조기귀가 신청 반려 안내","$adminName 선생님께서 조기귀가 신청을 반려하였습니다. ",deviceTokens)
+        sendNotification("조기귀가 신청 반려 안내", "$adminName 선생님께서 조기귀가 신청을 반려하였습니다. ", deviceTokens)
 
         eventPublisher.publishEvent(ChangeStatusRequest(this, applications.map { it.userId }))
     }

--- a/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/processor/EarlyReturnStatusProcessor.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/earlyreturn/service/processor/EarlyReturnStatusProcessor.kt
@@ -1,0 +1,14 @@
+package dsm.pick2024.domain.earlyreturn.service.processor
+
+import dsm.pick2024.domain.application.domain.Application
+import dsm.pick2024.domain.fcm.port.`in`.FcmSendMessageUseCase
+
+abstract class EarlyReturnStatusProcessor(
+    private val sendMessageUseCase: FcmSendMessageUseCase
+) {
+    abstract fun process(applications: List<Application>, adminName: String, deviceTokens: List<String>)
+
+    protected fun sendNotification(title: String, message: String, deviceTokens: List<String>) {
+        sendMessageUseCase.execute(deviceTokens, title, message)
+    }
+}


### PR DESCRIPTION
close #446 
조기귀가 및 외출 신청 리펙토링 및 중복 요청 가능 버그 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 신청 승인 및 거절 처리를 전담하는 프로세서가 도입되어, 승인/거절 시 알림 발송 및 상태 변경이 더욱 명확하게 처리됩니다.
  * 조기귀가 신청 승인 및 거절 시에도 전용 프로세서를 통해 알림 발송과 상태 변경이 이뤄집니다.

* **리팩터링**
  * 신청 및 조기귀가 상태 변경 로직이 간소화되어, 내부 동작이 더 명확하고 일관되게 개선되었습니다.
  * 출석 정보 저장 시 불변 리스트를 사용하도록 인터페이스가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->