### PR TITLE
458 비밀번호 변경 url 인가 수정

### DIFF
--- a/src/main/kotlin/dsm/pick2024/domain/user/facade/UserFacade.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/user/facade/UserFacade.kt
@@ -18,8 +18,8 @@ class UserFacade(
         return getUserByAccountId(accountId)
     }
 
-    override fun getUserByAccountId(id: String) =
-        queryUserPort.findByAccountId(id) ?: throw UserNotFoundException
+    override fun getUserByAccountId(accountId: String) =
+        queryUserPort.findByAccountId(accountId) ?: throw UserNotFoundException
 
     override fun getUserById(id: UUID): User =
         queryUserPort.findByUserId(id) ?: throw UserNotFoundException

--- a/src/main/kotlin/dsm/pick2024/domain/user/presentation/dto/request/PasswordResetRequest.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/user/presentation/dto/request/PasswordResetRequest.kt
@@ -12,6 +12,7 @@ data class PasswordResetRequest(
         message = "비밀번호는 영문자, 숫자, 특수문자를 포함해야 합니다"
     )
     val password: String,
+    val accountId: String,
     @field:NotBlank(message = "인증 코드는 필수입니다")
     @field:Size(min = 6, max = 6, message = "인증 코드는 6자리여야 합니다")
     val code: String

--- a/src/main/kotlin/dsm/pick2024/domain/user/service/PasswordResetService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/user/service/PasswordResetService.kt
@@ -18,7 +18,7 @@ class PasswordResetService(
 ) : PasswordResetUseCase {
     @Transactional
     override fun execute(request: PasswordResetRequest) {
-        val user = userFacadeUseCase.currentUser()
+        val user = userFacadeUseCase.getUserByAccountId(request.accountId)
 
         verifyMailUseCase.verifyAndConsume(request.code, user.accountId)
 

--- a/src/main/kotlin/dsm/pick2024/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/dsm/pick2024/global/config/security/SecurityConfig.kt
@@ -47,7 +47,8 @@ class SecurityConfig(
                 "/mail/send",
                 "/mail/check",
                 "/admin/signup",
-                "/PiCK_Logo.png"
+                "/PiCK_Logo.png",
+                "/user/password"
             ).permitAll()
             .antMatchers(
                 HttpMethod.POST,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 로그인 없이 계정 ID로 비밀번호 재설정 가능
  - 비밀번호 재설정 엔드포인트를 공개 경로로 허용(/user/password)
- 문서
  - 비밀번호 재설정 요청 본문에 accountId 필드가 추가됨 (password, code와 함께 전송 필요)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->